### PR TITLE
Added minimum value for perl to Prereqs in dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,6 +15,7 @@ exclude_match = tmp/*
 [Manifest]
 
 [Prereqs]
+perl         = 5.006
 Carp         = 1.03
 Test::More   = 0.47
 XML::Writer  = 0.531


### PR DESCRIPTION
perlver claimed 5.6.0 was sufficient

I'm doing the CPAN challenge and was assigned this module. I'm making a minimal change that will increase the Kwalitee score to get my feet wet. If there is something more useful that I might do, I'm open to suggestions for things to look at. Thanks.
